### PR TITLE
feat: Support Fleet on presudo sdk 

### DIFF
--- a/src/SimpleGrpc/AgonesAspNetCore/AgonesOptions.cs
+++ b/src/SimpleGrpc/AgonesAspNetCore/AgonesOptions.cs
@@ -7,13 +7,13 @@ public class AgonesOptions
     /// </summary>
     public CancellationTokenSource SdkCancellationTokenSource { get; } = new CancellationTokenSource();
     /// <summary>
-    /// AgonesSDK Emulator Return GameServer Name
+    /// AgonesSDK Emulator Fleet Name
     /// </summary>
-    public string EmulateSdkName { get; set; } = "DummyGameServer";
+    public string EmulateSdkFleetName { get; set; } = "dummyfleet";
     /// <summary>
     /// AgonesSDK Emulator Return GameServer Namespace
     /// </summary>
-    public string EmulateSdkNameSpace { get; set; } = "DummyGameServer";
+    public string EmulateSdkNameSpace { get; set; } = "default";
     /// <summary>
     /// AgonesSDK Emulator Return GameServer port
     /// </summary>


### PR DESCRIPTION
## tl;dr;

Current AgonesPresudoSDK not support Fleet, but Agones Allocate should be used in Fleet scenario.
Let's change to use Fleet instead of GameServer in AgonesOptions.