### PR TITLE
feat: AgonesSDKAccessor to support multi server in single process

### DIFF
--- a/src/SimpleGrpc/AgonesAspNetCore/AgoneSdkServiceExtensions.cs
+++ b/src/SimpleGrpc/AgonesAspNetCore/AgoneSdkServiceExtensions.cs
@@ -26,6 +26,9 @@ public static class AgoneSdkServiceExtensions
             IAgonesSDK sdk = KubernetesServiceProvider.Current.IsRunningOnKubernetes
                 ? new AgonesSDK(cancellationTokenSource: options.Value.SdkCancellationTokenSource, logger: logger)
                 : new AgonesSDKPresudo(options, logger);
+
+            // Other servers in same process can access to IAgonesSDK through Accessor.
+            AgonesSDKAccessor.SetAgonesSDK(sdk);
             return sdk;
         });
         services.TryAddSingleton<AgonesCondition>();

--- a/src/SimpleGrpc/AgonesAspNetCore/AgonesSDKAccessor.cs
+++ b/src/SimpleGrpc/AgonesAspNetCore/AgonesSDKAccessor.cs
@@ -1,0 +1,21 @@
+﻿using Agones;
+
+namespace AgonesAspNetCore;
+
+// multi instance in single server may required to acces IAgonesSDK to operate SDK status directly.
+/// <summary>
+/// Offer IAgonesSDK access.
+/// </summary>
+public static class AgonesSDKAccessor
+{
+    /// <summary>
+    /// Offer IAgonesSDK access. null represent IAgonesSDK is not yet available.
+    /// </summary>
+    public static IAgonesSDK? AgonesSdk { get; private set; }
+
+    /// <summary>
+    /// Set IAgonesSDK to be accessible.
+    /// </summary>
+    /// <param name="agonesSDK"></param>
+    public static void SetAgonesSDK(IAgonesSDK agonesSDK) => AgonesSdk = agonesSDK;
+}


### PR DESCRIPTION
## tl;dr;

Kestel may host multi servers in single process, like debug server and gRPC server.

`AgonesSDKAccessor` allows debug server access IAgonesSDK which initialized in gRPC Server.